### PR TITLE
Do not use 'which' to check for command availability

### DIFF
--- a/lib/command-exists.js
+++ b/lib/command-exists.js
@@ -3,17 +3,12 @@
 var exec = require('child_process').exec;
 
 module.exports = function(commandName, callback) {
-    var child = exec('command -v ' + commandName + 
-        ' >/dev/null 2>&1' +
-        ' || { echo >&2 \'' + commandName + ' not found\'; exit 1; }');
-    // exits too early
-    var gotData = true;
-    
-    child.stderr.on('data', function(data) {
-        gotData = false;
-    });
 
-    child.on('close', function() {
-        callback(null, gotData);
-    });
+    var child = exec('command -v ' + commandName + 
+        ' 2>/dev/null' +
+        ' && { echo >&1 \'' + commandName + ' found\'; exit 0; }',
+        (error, stdout, stderr) => {
+            callback(null, !!stdout);
+        });
+
 };

--- a/lib/command-exists.js
+++ b/lib/command-exists.js
@@ -3,11 +3,14 @@
 var exec = require('child_process').exec;
 
 module.exports = function(commandName, callback) {
-    var child = exec('which ' + commandName);
-    var gotData = false;
+    var child = exec('command -v ' + commandName + 
+        ' >/dev/null 2>&1' +
+        ' || { echo >&2 \'' + commandName + ' not found\'; exit 1; }');
+    // exits too early
+    var gotData = true;
     
-    child.stdout.on('data', function() {
-        gotData = true;
+    child.stderr.on('data', function(data) {
+        gotData = false;
     });
 
     child.on('close', function() {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "command-exists",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "check whether a command line command exists in the current environment",
   "main": "index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
   "homepage": "https://github.com/mathisonian/command-exists",
   "devDependencies": {
     "expect.js": "^0.3.1",
+    "jshint": "^2.9.1",
     "mocha": "^1.21.4"
   }
 }

--- a/test/test.js
+++ b/test/test.js
@@ -3,7 +3,6 @@
 var expect = require('expect.js');
 var commandExists = require('..');
 
-
 describe('commandExists()', function(){
 
     it('it should find a command named ls', function(done){


### PR DESCRIPTION
Per [this stackoverflow post](http://stackoverflow.com/questions/592620/check-if-a-program-exists-from-a-bash-script) do not use 'which' to check for command availability.

Swapped it out in favor of command -v.

Passes tests.