### PR TITLE
Fixes commandExists on windows

### DIFF
--- a/lib/command-exists.js
+++ b/lib/command-exists.js
@@ -2,13 +2,33 @@
 
 var exec = require('child_process').exec;
 
-module.exports = function(commandName, callback) {
+var isUsingWindows = process.platform == 'win32'
 
-    var child = exec('command -v ' + commandName +
+var commandExistsUnix = function(commandName, callback) {
+	var child = exec('command -v ' + commandName +
         ' 2>/dev/null' +
         ' && { echo >&1 \'' + commandName + ' found\'; exit 0; }',
         function (error, stdout, stderr) {
             callback(null, !!stdout);
         });
+}
 
+var commandExistsWindows = function function_name(commandName, callback) {
+	var child = exec('where ' + commandName,
+		function (error) {
+			if (error !== null){
+            	callback(null, false);
+			} else {
+				callback(null, true);
+			}
+        }
+	)
+}
+
+module.exports = function(commandName, callback) {
+	if (isUsingWindows) {
+		commandExistsWindows(commandName, callback)
+	} else {
+		commandExistsUnix(commandName, callback)
+	}
 };

--- a/package.json
+++ b/package.json
@@ -16,6 +16,9 @@
     "exists"
   ],
   "author": "Matthew Conlen",
+  "contributors": [
+    "Arthur Silber <arthur@arthursilber.de> (https://arthursilber.de)"
+  ],
   "license": "MIT",
   "bugs": {
     "url": "https://github.com/mathisonian/command-exists/issues"

--- a/test/test.js
+++ b/test/test.js
@@ -2,11 +2,17 @@
 
 var expect = require('expect.js');
 var commandExists = require('..');
+var isUsingWindows = process.platform == 'win32'
 
 describe('commandExists()', function(){
 
-    it('it should find a command named ls', function(done){
-        commandExists('ls', function(err, exists) {
+    it('it should find a command named ls or dir', function(done){
+        var commandToUse = 'ls'
+        if (isUsingWindows) {
+            commandToUse = 'dir'
+        }
+
+        commandExists(commandToUse, function(err, exists) {
             expect(err).to.be(null);
             expect(exists).to.be(true);
             done();


### PR DESCRIPTION
Per default, commandExists always fails on windows.

This PR introduces a switch to use the `where` command on windows, and uses the existing code on linux.
Requires the mocha-not-found-fix to pass all tests on windows (PR #3 ).
