### PR TITLE
Applied fix for wrong ID of local non-executable as executable (on Linux).

### DIFF
--- a/lib/command-exists.js
+++ b/lib/command-exists.js
@@ -2,16 +2,61 @@
 
 var exec = require('child_process').exec;
 var execSync = require('child_process').execSync;
+var access = require('fs').access;
+var accessSync = require('fs').accessSync;
+var constants = require('fs').constants;
 
 var isUsingWindows = process.platform == 'win32'
 
+var fileNotExists = function(commandName, callback){
+    access(commandName, constants.F_OK,
+    function(err){
+        callback(!err);
+    });
+};
+
+var fileNotExistsSync = function(commandName){
+    try{
+        accessSync(commandName, constants.F_OK);
+        return false;
+    }catch(e){
+        return true;
+    }
+};
+
+var localExecutable = function(commandName, callback){
+    access(commandName, constants.F_OK | constants.X_OK,
+        function(err){
+        callback(null, !err);
+    });
+};
+
+var localExecutableSync = function(commandName){
+    try{
+        accessSync(commandName, constants.F_OK | constants.X_OK);
+        return true;
+    }catch(e){
+        return false;
+    }
+}
+
 var commandExistsUnix = function(commandName, callback) {
-  var child = exec('command -v ' + commandName +
-        ' 2>/dev/null' +
-        ' && { echo >&1 \'' + commandName + ' found\'; exit 0; }',
-        function (error, stdout, stderr) {
-            callback(null, !!stdout);
-        });
+
+    fileNotExists(commandName, function(isFile){
+
+        if(!isFile){
+            var child = exec('command -v ' + commandName +
+                  ' 2>/dev/null' +
+                  ' && { echo >&1 \'' + commandName + ' found\'; exit 0; }',
+                  function (error, stdout, stderr) {
+                      callback(null, !!stdout);
+                  });
+            return;
+        }
+
+        localExecutable(commandName, callback);
+    });
+
 }
 
 var commandExistsWindows = function(commandName, callback) {
@@ -27,15 +72,20 @@ var commandExistsWindows = function(commandName, callback) {
 }
 
 var commandExistsUnixSync = function(commandName) {
-  try {
-    var stdout = execSync('command -v ' + commandName +
-          ' 2>/dev/null' +
-          ' && { echo >&1 \'' + commandName + ' found\'; exit 0; }'
-          );
-    return !!stdout;
-  } catch (error) {
-    return false;
+  if(fileNotExistsSync(commandName)){
+      try {
+        var stdout = execSync('command -v ' + commandName +
+              ' 2>/dev/null' +
+              ' && { echo >&1 \'' + commandName + ' found\'; exit 0; }'
+              );
+        return !!stdout;
+      } catch (error) {
+        return false;
+      }
   }
+
+  return localExecutableSync(commandName);
+
 }
 
 var commandExistsWindowsSync = function(commandName, callback) {


### PR DESCRIPTION
I had to add a fileNotExists function too. I hope that's ok. There is a check for existence by the localExecutable function as well so it there shouldn't be too big of a problem.

This should work on other Unixes too.

Could you post back when you've published to npm?