### PR TITLE
Prevent logs in commandExistsWindowsSync. fix #18

### DIFF
--- a/lib/command-exists.js
+++ b/lib/command-exists.js
@@ -89,7 +89,7 @@ var commandExistsUnixSync = function(commandName, cleanedCommandName) {
 
 var commandExistsWindowsSync = function(commandName, cleanedCommandName, callback) {
   try {
-      var stdout = execSync('where ' + cleanedCommandName);
+      var stdout = execSync('where ' + cleanedCommandName, {stdio: []});
       return !!stdout;
   } catch (error) {
       return false;


### PR DESCRIPTION
The default value of `stdio.options` in `execSync` is 'pipe'. 
- That is *supposed* to be equivalent to `['pipe', 'pipe', 'pipe']`. 
- In reality there seems to be a difference here - using the default (or 'pipe') results in the extra log. Using an array solves the issue. 

This PR uses an empty array since `null`/`undefined` is equivalent to 'pipe' for indices 0-2 and 'ignore' for 3+ (where the logs might be coming from).

Other things I've tried: 
- `{stdio: 'pipe'}` - same as default, so doesn't fix the issue
- setting `stdin, stdout, stderr` as separate keys - doesn't help either (perhaps because the problem comes from a 4th stream)
- setting to `ignore` - this breaks the functionality of the module, so not an option
- `{stdio: ['pipe', 'pipe', 'pipe']}` - fixes the issue the same way the current fix does, but seems a bit unnecessary.

Relevant links:
- [execSync options](https://nodejs.org/api/child_process.html#child_process_child_process_execsync_command_options)
- [options.stdio](https://nodejs.org/api/child_process.html#child_process_options_stdio)

The fix is small (one line), so feel free to merge it if you feel like it. However since you mentioned that you don't have a working windows environment it would also be fine if you don't want to merge it.