### PR TITLE
Fixed commandExists() not working for absolute path on windows

### DIFF
--- a/lib/command-exists.js
+++ b/lib/command-exists.js
@@ -62,7 +62,8 @@ var commandExistsUnix = function(commandName, cleanedCommandName, callback) {
 }
 
 var commandExistsWindows = function(commandName, cleanedCommandName, callback) {
-  if (/[\x00-\x1f<>:"\|\?\*]/.test(commandName)) {
+  // Regex from Julio from: https://stackoverflow.com/questions/51494579/regex-windows-path-validator
+  if (!(/^(?!(?:.*\s|.*\.|\W+)$)(?:[a-zA-Z]:)?(?:(?:[^<>:"\|\?\*\n])+(?:\/\/|\/|\\\\|\\)?)+$/m.test(commandName))) {
     callback(null, false);
     return;
   }
@@ -93,7 +94,8 @@ var commandExistsUnixSync = function(commandName, cleanedCommandName) {
 }
 
 var commandExistsWindowsSync = function(commandName, cleanedCommandName, callback) {
-  if (/[\x00-\x1f<>:"\|\?\*]/.test(commandName)) {
+  // Regex from Julio from: https://stackoverflow.com/questions/51494579/regex-windows-path-validator
+  if (!(/^(?!(?:.*\s|.*\.|\W+)$)(?:[a-zA-Z]:)?(?:(?:[^<>:"\|\?\*\n])+(?:\/\/|\/|\\\\|\\)?)+$/m.test(commandName))) {
     return false;
   }
   try {

--- a/test/test.js
+++ b/test/test.js
@@ -7,10 +7,10 @@ var isUsingWindows = process.platform == 'win32'
 
 describe('commandExists', function(){
     describe('async - callback', function() {
-        it('it should find a command named ls or dir', function(done){
+        it('it should find a command named ls or xcopy', function(done){
             var commandToUse = 'ls'
             if (isUsingWindows) {
-                commandToUse = 'dir'
+                commandToUse = 'xcopy'
             }
 
             commandExists(commandToUse, function(err, exists) {
@@ -30,10 +30,10 @@ describe('commandExists', function(){
     });
 
     describe('async - promise', function() {
-        it('it should find a command named ls or dir', function(done){
+        it('it should find a command named ls or xcopy', function(done){
             var commandToUse = 'ls'
             if (isUsingWindows) {
-                commandToUse = 'dir'
+                commandToUse = 'xcopy'
             }
 
             commandExists(commandToUse)
@@ -56,10 +56,10 @@ describe('commandExists', function(){
     });
 
     describe('sync', function() {
-        it('it should find a command named ls or dir', function(){
+        it('it should find a command named ls or xcopy', function(){
             var commandToUse = 'ls'
             if (isUsingWindows) {
-                commandToUse = 'dir'
+                commandToUse = 'xcopy'
             }
             expect(commandExistsSync(commandToUse)).to.be(true);
         });
@@ -68,10 +68,10 @@ describe('commandExists', function(){
             expect(commandExistsSync('fdsafdsafdsafdsafdsa')).to.be(false);
         });
 
-        it('it should not find a command named ls or dir prefixed with some nonsense', function(){
+        it('it should not find a command named ls or xcopy prefixed with some nonsense', function(){
             var commandToUse = 'fdsafdsa ls'
             if (isUsingWindows) {
-                commandToUse = 'fdsafdsaf dir'
+                commandToUse = 'fdsafdsaf xcopy'
             }
             expect(commandExistsSync(commandToUse)).to.be(false);
         });

--- a/test/test.js
+++ b/test/test.js
@@ -130,35 +130,18 @@ describe('commandExists', function(){
     });
 
     describe('absolute path', function() {
-        if (!isUsingWindows) {
-            it('it should report true if there is a command with that name in absolute path', function(done) {
-                var commandToUse = resolve('test/executable-script.js');
-                commandExists(commandToUse)
-                .then(function(command){
-                    expect(command).to.be(commandToUse);
-                    done();
-                });
+        it('it should report true if there is a command with that name in absolute path', function(done) {
+            var commandToUse = resolve('test/executable-script.js');
+            commandExists(commandToUse)
+            .then(function(command){
+                expect(command).to.be(commandToUse);
+                done();
             });
-            
-            it('it should report false if there is not a command with that name in absolute path', function() {
-                var commandToUse = resolve('executable-script.js');
-                expect(commandExists.sync(commandToUse)).to.be(false);
-            });
-        }
-        if (isUsingWindows) {
-            it('it should report true if there is a command with that name in absolute path', function(done) {
-                var commandToUse = resolve('test\\executable-script.cmd');
-                commandExists(commandToUse)
-                .then(function(command){
-                    expect(command).to.be(commandToUse);
-                    done();
-                });
-            });
-            
-            it('it should report false if there is not a command with that name in absolute path', function() {
-                var commandToUse = resolve('executable-script.cmd');
-                expect(commandExists.sync(commandToUse)).to.be(false);
-            });
-        }
+        });
+        
+        it('it should report false if there is not a command with that name in absolute path', function() {
+            var commandToUse = resolve('executable-script.js');
+            expect(commandExists.sync(commandToUse)).to.be(false);
+        });
     });
 });

--- a/test/test.js
+++ b/test/test.js
@@ -132,7 +132,7 @@ describe('commandExists', function(){
     describe('absolute path', function() {
         if (!isUsingWindows) {
             it('it should report true if there is a command with that name in absolute path', function(done) {
-                var commandToUse = resolve('./test/executable-script.cmd')
+                var commandToUse = resolve('test/executable-script.js');
                 commandExists(commandToUse)
                 .then(function(command){
                     expect(command).to.be(commandToUse);
@@ -141,13 +141,13 @@ describe('commandExists', function(){
             });
             
             it('it should report false if there is not a command with that name in absolute path', function() {
-                var commandToUse = resolve('./executable-script.cmd')
+                var commandToUse = resolve('executable-script.js');
                 expect(commandExists.sync(commandToUse)).to.be(false);
             });
         }
         if (isUsingWindows) {
             it('it should report true if there is a command with that name in absolute path', function(done) {
-                var commandToUse = resolve('.\\test\\executable-script.cmd')
+                var commandToUse = resolve('test\\executable-script.cmd');
                 commandExists(commandToUse)
                 .then(function(command){
                     expect(command).to.be(commandToUse);
@@ -156,7 +156,7 @@ describe('commandExists', function(){
             });
             
             it('it should report false if there is not a command with that name in absolute path', function() {
-                var commandToUse = resolve('.\\executable-script.cmd')
+                var commandToUse = resolve('executable-script.cmd');
                 expect(commandExists.sync(commandToUse)).to.be(false);
             });
         }

--- a/test/test.js
+++ b/test/test.js
@@ -3,6 +3,7 @@
 var expect = require('expect.js');
 var commandExists = require('..');
 var commandExistsSync = commandExists.sync;
+var resolve = require('path').resolve;
 var isUsingWindows = process.platform == 'win32'
 
 describe('commandExists', function(){
@@ -123,6 +124,39 @@ describe('commandExists', function(){
 
             it('it should report false if there is a double quotation mark in the file path', function() {
                 var commandToUse = 'test\\"executable-script.cmd'
+                expect(commandExists.sync(commandToUse)).to.be(false);
+            });
+        }
+    });
+
+    describe('absolute path', function() {
+        if (!isUsingWindows) {
+            it('it should report true if there is a command with that name in absolute path', function(done) {
+                var commandToUse = resolve('./test/executable-script.cmd')
+                commandExists(commandToUse)
+                .then(function(command){
+                    expect(command).to.be(commandToUse);
+                    done();
+                });
+            });
+            
+            it('it should report false if there is not a command with that name in absolute path', function() {
+                var commandToUse = resolve('./executable-script.cmd')
+                expect(commandExists.sync(commandToUse)).to.be(false);
+            });
+        }
+        if (isUsingWindows) {
+            it('it should report true if there is a command with that name in absolute path', function(done) {
+                var commandToUse = resolve('.\\test\\executable-script.cmd')
+                commandExists(commandToUse)
+                .then(function(command){
+                    expect(command).to.be(commandToUse);
+                    done();
+                });
+            });
+            
+            it('it should report false if there is not a command with that name in absolute path', function() {
+                var commandToUse = resolve('.\\executable-script.cmd')
                 expect(commandExists.sync(commandToUse)).to.be(false);
             });
         }


### PR DESCRIPTION
This fixes issue #23, where the RegEx check that causes commandExistsWindows async/sync to return early for commands with an absolute path, e.g. `C:\Program Files\...`

Also included absolute paths test in `test.js` and replaced `dir` with `xcopy` because `dir` is not a command that has an associated file. `where dir` will never return true on Windows.