### PR TITLE
Return a boolean instead of throwing null

### DIFF
--- a/lib/command-exists.js
+++ b/lib/command-exists.js
@@ -132,10 +132,10 @@ module.exports = function commandExists(commandName, callback) {
   if (!callback && typeof Promise !== 'undefined') {
     return new Promise(function(resolve, reject){
       commandExists(commandName, function(error, output) {
-        if (output) {
-          resolve(commandName);
-        } else {
+        if (error) {
           reject(error);
+        } else {
+          resolve(output ? commandName : false);
         }
       });
     });

--- a/test/test.js
+++ b/test/test.js
@@ -46,11 +46,13 @@ describe('commandExists', function(){
 
         it('it should not find a command named fdsafdsafdsafdsafdsa', function(done){
             commandExists('fdsafdsafdsafdsafdsa')
-            .then(function() {
-                // We should not execute this line.
-                expect(true).to.be(false);
+            .then(function(command) {
+                expect(command).to.be(false);
+                done();
             })
-            .catch(function() {
+            .catch(function(error) {
+                // We should not execute this line.
+                expect(error).to.be(null);
                 done();
             });
         });
@@ -91,9 +93,10 @@ describe('commandExists', function(){
             var commandToUse = 'test/non-executable-script.js'
             commandExists(commandToUse)
                 .then(function(command){
-                    // We should not execute this line.
-                    expect(true).to.be(false);
+                    expect(command).to.be(false);
+                    done();
                 }).catch(function(err){
+                    // We should not execute this line.
                     expect(err).to.be(null);
                     done();
                 });


### PR DESCRIPTION
This resolves #22 by returning false instead of throwing `null` when using promises.